### PR TITLE
Added size: 10000 in the _reindex 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ RESPONSE=$(curl -s -k -w "\n%{http_code}\n" \
 {
   \"source\": {
     \"index\": \"$SOURCE_INDEX\",
+    \"size\": 10000,
     \"query\": {
       \"range\": {
         \"@timestamp\": {

--- a/README.md
+++ b/README.md
@@ -112,6 +112,44 @@ echo "Finished Wazuh alerts copy"
 echo "=============================="
 ```
 
+You can also narrow down the alerting level by specifying rule.level as a parameter:
+
+```json
+{
+  \"source\": {
+    \"index\": \"$SOURCE_INDEX\",
+    \"size\": 10000,
+    \"query\": {
+      \"bool\": {
+        \"must\": [
+          {
+            \"range\": {
+              \"@timestamp\": {
+                \"gte\": \"$LAST_RUN\",
+                \"lte\": \"$NOW\"
+              }
+            }
+          },
+          {
+            \"range\": {
+              \"rule.level\": {
+                \"gte\": 9,
+                \"lt\": 16
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  \"dest\": {
+    \"index\": \"$DEST_INDEX\",
+    \"pipeline\": \"wazuh_workflow_pipeline\"
+  }
+}
+")
+```
+
 Make it executable:
 
 ```bash

--- a/wazuh-indexer-config/copy_wazuh_alerts.sh
+++ b/wazuh-indexer-config/copy_wazuh_alerts.sh
@@ -35,6 +35,7 @@ curl -v -k -X POST "$ES_HOST/_reindex?pretty" \
 {
   \"source\": {
     \"index\": \"$SOURCE_INDEX\",
+     \"size\": 10000,
     \"query\": {
       \"range\": {
         \"@timestamp\": {


### PR DESCRIPTION
Added size: 10000 in the _reindex request to reduce the number of batches and minimize timeouts when handling larger alert volumes. With this change the reindex runs faster (1 batch in this test window), but the execution log shows errors on the destination index:

`"failures":[
  ...,
  {"reason":"Limit of total fields [1000] has been exceeded","status":400},
  ...
]`
